### PR TITLE
Alterações para correção de erro na instalação e exibição da porta no console.

### DIFF
--- a/src/Horse.NewProject.Templates.pas
+++ b/src/Horse.NewProject.Templates.pas
@@ -82,9 +82,10 @@ resourcestring
     '    end);' + sLineBreak +
     '' + sLineBreak +
     '  THorse.Listen(%1:s, ' + sLineBreak +
-    '    procedure(Horse: THorse)' + sLineBreak +
+    '    procedure' + sLineBreak +
     '    begin' + sLineBreak +
-    '      Writeln(''Server is runing on port '' + IntToStr(Horse.Port));' + sLineBreak +
+    '      Writeln(''Server is runing on port '' + IntToStr(THorse.Port));' + sLineBreak +
+    '      Readln;' + sLineBreak +
     '    end);' + sLineBreak +
     'end.';
 


### PR DESCRIPTION

Alterado o arquivo Horse.NewProject.Templates.pas em sHorseDPRConsole para correta exibição da porta num projeto console

Alterado o arquivo Horse.Boss.Initializer.pas em RunBossInstall extraído os métodos OnNewLineEvent e OnTerminatedEvent a fim de evitar o erro abaixo:

[dcc32 Error] Horse.Boss.Initializer.pas(103): E2010 Incompatible types: 'TNewLineEvent' and 'Procedure'
[dcc32 Error] Horse.Boss.Initializer.pas(114): E2250 There is no overloaded version of 'Queue' that can be called with these arguments
[dcc32 Fatal Error] horse_wizard.dpk(44): F2063 Could not compile used unit 'Horse.Boss.Initializer.pas'
