### PR TITLE
Replaced "DisposeOf" with "Free"

### DIFF
--- a/src/Horse.Boss.Initializer.pas
+++ b/src/Horse.Boss.Initializer.pas
@@ -71,7 +71,7 @@ begin
     LFile.Text := LContent;
     LFile.SaveToFile(TPath.Combine(ExtractFilePath(FProject.FileName), BOSS_NAME));
   finally
-    LFile.DisposeOf;
+    LFile.Free;
   end;
 
   RunBossInstall;


### PR DESCRIPTION
I did this because "DisposeOf" is marked as deprecated since Delphi 12 Athens and you should be using "Free" instead.